### PR TITLE
Add issuing-billing-transaction and issuing-billing-invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 ## [Unreleased]
 
+### Added
+- IssuingBillingTransaction resource
+- IssuingBillingInvoice resource
+
 ## [0.15.0] - 2025-03-19
 ### Added
 - operator_email and operator_phone to PixInfraction resource
@@ -22,7 +26,6 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 ### Added
 - description to BR Code preview
 - data to Dynamic BR Code
-
 ### Fixed
 - readme
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This SDK version is compatible with the Stark Infra API v2.
         - [Balance](#get-your-issuingbalance): View your issuing balance
         - [Transactions](#query-issuingtransactions): View the transactions that have affected your issuing balance
         - [Enums](#issuing-enums): Query enums related to the issuing purchases, such as merchant categories, countries and card purchase methods
+        - [Billing Invoices](#issuing-billinginvoice): View your current billing invoices
+        - [Billing Transactions](#issuing-billingtransaction): View your current billing transactions
     - [Pix](#pix)
         - [PixRequests](#create-pixrequests): Create Pix transactions
         - [PixReversals](#create-pixreversals): Reverse Pix transactions
@@ -1348,6 +1350,52 @@ methods = starkinfra.cardmethod.query(
 
 for method in methods:
     print(method)
+```
+
+### Query IssuingBillingInvoices
+
+You can query multiples available Billing Invoices using this resource.
+
+```python
+import starkinfra
+from datetime import date
+
+billing_invoices = starkinfra.issuingbillinginvoice.query(
+    after=date(2023, 1, 1),
+    before=date(2024, 3, 1),
+    limit=10
+)
+
+for billing_invoice in billing_invoices:
+    print(billing_invoice)
+```
+
+### Get an IssuingBillingInvoice
+
+```python
+import starkinfra
+
+billing_invoice = starkinfra.issuingbillinginvoice.get("9302937674764487")
+
+print(billing_invoice)
+```
+
+### Query IssuingBillingTransactions
+
+You can query multiples available Billing Transaction invoices using this resource.
+
+```python
+import starkinfra
+from datetime import date
+
+billing_transactions = starkinfra.issuingbillingtransaction.query(
+    after=date(2023, 1, 1),
+    before=date(2024, 3, 1),
+    limit=10
+)
+
+for billing_transaction in billing_transactions:
+    print(billing_transaction)
 ```
 
 ## Pix

--- a/starkinfra/__init__.py
+++ b/starkinfra/__init__.py
@@ -51,6 +51,12 @@ from .pixuser.__pixuser import PixUser
 from . import issuingbalance
 from .issuingbalance.__issuingbalance import IssuingBalance
 
+from . import issuingbillinginvoice
+from .issuingbillinginvoice.__issuingbillinginvoice import IssuingBillingInvoice
+
+from . import issuingbillingtransaction
+from .issuingbillingtransaction.__issuingbillingtransaction import IssuingBillingTransaction
+
 from . import creditnote
 from .creditnote.__creditnote import CreditNote
 

--- a/starkinfra/issuingbillinginvoice/__init__.py
+++ b/starkinfra/issuingbillinginvoice/__init__.py
@@ -1,0 +1,1 @@
+from .__issuingbillinginvoice import get, query, page

--- a/starkinfra/issuingbillinginvoice/__issuingbillinginvoice.py
+++ b/starkinfra/issuingbillinginvoice/__issuingbillinginvoice.py
@@ -1,0 +1,71 @@
+from ..utils import rest
+from starkcore.utils.resource import Resource
+from starkcore.utils.checks import check_datetime, check_date
+
+
+class IssuingBillingInvoice(Resource):
+    """# IssuingBillingInvoice object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-invoice
+    """
+
+    def __init__(self, id=None, name=None, tax_id=None, fine=None, interest=None, status=None, amount=None,
+                 nominal_amount=None, brcode=None, link=None, due=None, start=None, end=None, created=None,
+                 updated=None):
+        Resource.__init__(self, id=id)
+
+        self.tax_id = tax_id
+        self.name = name
+        self.fine = fine
+        self.interest = interest
+        self.status = status
+        self.amount = amount
+        self.nominal_amount = nominal_amount
+        self.brcode = brcode
+        self.link = link
+        self.due = check_datetime(due)
+        self.start = check_datetime(start)
+        self.end = check_datetime(end)
+        self.created = check_datetime(created)
+        self.updated = check_datetime(updated)
+
+
+_resource = {"class": IssuingBillingInvoice, "name": "IssuingBillingInvoice"}
+
+
+def get(id, user=None):
+    """# IssuingBillingInvoice object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-invoice
+    """
+    return rest.get_id(resource=_resource, id=id, user=user)
+
+
+def query(limit=None, after=None, before=None, status=None, id=None, tags=None, user=None):
+    """# IssuingBillingInvoice object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-invoice
+    """
+    return rest.get_stream(
+        resource=_resource,
+        status=status,
+        after=check_datetime(after),
+        before=check_datetime(before),
+        id=id,
+        tags=tags,
+        limit=limit,
+        user=user,
+    )
+
+
+def page(cursor=None, limit=None, after=None, before=None, status=None, tags=None, user=None):
+    """# IssuingBillingInvoice object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-invoice
+    """
+    return rest.get_page(
+        resource=_resource,
+        cursor=cursor,
+        status=status,
+        after=check_datetime(after),
+        before=check_datetime(before),
+        tags=tags,
+        limit=limit,
+        user=user,
+    )

--- a/starkinfra/issuingbillingtransaction/__init__.py
+++ b/starkinfra/issuingbillingtransaction/__init__.py
@@ -1,0 +1,1 @@
+from .__issuingbillingtransaction import query, page

--- a/starkinfra/issuingbillingtransaction/__issuingbillingtransaction.py
+++ b/starkinfra/issuingbillingtransaction/__issuingbillingtransaction.py
@@ -1,0 +1,63 @@
+from ..utils import rest
+from starkcore.utils.resource import Resource
+from starkcore.utils.checks import check_datetime, check_date
+
+
+class IssuingBillingTransaction(Resource):
+    """# IssuingBillingTransaction object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-transaction
+    """
+
+    def __init__(self, id=None, amount=None, invoice_id=None, installment=None, installment_count=None,
+                 balance=None, holder_name=None, source=None, external_id=None, description=None, card_ending=None,
+                 tax=None, rate=None, merchant_amount=None, merchant_currency_code=None, created=None):
+        Resource.__init__(self, id=id)
+
+        self.amount = amount
+        self.invoice_id = invoice_id
+        self.installment = installment
+        self.installment_count = installment_count
+        self.balance = balance
+        self.holder_name = holder_name
+        self.source = source
+        self.external_id = external_id
+        self.description = description
+        self.card_ending = card_ending
+        self.tax = tax
+        self.rate = rate
+        self.merchant_amount = merchant_amount
+        self.merchant_currency_code = merchant_currency_code
+        self.created = check_datetime(created)
+
+
+_resource = {"class": IssuingBillingTransaction, "name": "IssuingBillingTransaction"}
+
+
+def query(limit=None, after=None, before=None, invoice_id=None, tags=None, user=None):
+    """# IssuingBillingTransaction object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-transaction
+    """
+    return rest.get_stream(
+        resource=_resource,
+        after=check_datetime(after),
+        before=check_datetime(before),
+        invoice_id=invoice_id,
+        tags=tags,
+        limit=limit,
+        user=user,
+    )
+
+def page(cursor=None, limit=None, after=None, before=None, invoice_id=None, tags=None, user=None):
+    """# IssuingBillingTransaction object
+    Check out our API Documentation at https://starkinfra.com/docs/api#issuing-billing-transaction
+    """
+    return rest.get_page(
+        resource=_resource,
+        cursor=cursor,
+        after=check_datetime(after),
+        before=check_datetime(before),
+        tags=tags,
+        invoice_id=invoice_id,
+        limit=limit,
+        user=user,
+    )

--- a/tests/sdk/testIssuingBillingInvoice.py
+++ b/tests/sdk/testIssuingBillingInvoice.py
@@ -1,0 +1,42 @@
+import starkinfra
+from unittest import TestCase, main
+from datetime import date, timedelta
+from tests.utils.user import exampleProject
+
+starkinfra.user = exampleProject
+
+
+class TestIssuingBillingInvoiceGet(TestCase):
+
+    def test_success(self):
+        billing_invoices = starkinfra.issuinginvoice.query(limit=1)
+        billing_invoice = starkinfra.issuinginvoice.get(id=next(billing_invoices).id)
+        self.assertEqual(billing_invoice.id, str(billing_invoice.id))
+
+
+class TestIssuingBillingInvoiceQuery(TestCase):
+
+    def test_success(self):
+        billing_invoices = starkinfra.issuingbillinginvoice.query(
+            after=date.today() - timedelta(days=100),
+            before=date.today()
+        )
+        for billing_invoice in billing_invoices:
+            self.assertEqual(billing_invoice.id, str(billing_invoice.id))
+
+
+class TestIssuingBillingInvoicePage(TestCase):
+
+    def test_success(self):
+        billing_invoices = starkinfra.issuingbillinginvoice.page(
+            after=date.today() - timedelta(days=100),
+            before=date.today(),
+            limit = 10,
+            cursor = None
+        )
+        for billing_invoice in billing_invoices:
+            self.assertEqual(billing_invoice.id, str(billing_invoice.id))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/sdk/testIssuingBillingTransaction.py
+++ b/tests/sdk/testIssuingBillingTransaction.py
@@ -1,0 +1,33 @@
+import starkinfra
+from unittest import TestCase, main
+from datetime import date, timedelta
+from tests.utils.user import exampleProject
+
+
+starkinfra.user = exampleProject
+
+
+class TestIssuingBillingTransactionQuery(TestCase):
+
+    def test_success(self):
+        billing_transactions = starkinfra.issuingbillingtransaction.query(
+            after=date.today() - timedelta(days=100),
+            before=date.today()
+        )
+        for billing_transaction in billing_transactions:
+            self.assertEqual(billing_transaction.id, str(billing_transaction.id))
+
+class TestIssuingBillingTransactionPage(TestCase):
+
+    def test_success(self):
+        billing_transactions = starkinfra.issuingbillingtransaction.page(
+            after=date.today() - timedelta(days=100),
+            before=date.today(),
+            limit = 10,
+            cursor = None
+        )
+        for billing_transaction in billing_transactions:
+            self.assertEqual(billing_transaction.id, str(billing_transaction.id))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Description and impact
Adding resources in issuing-billing-invoice and adding resources in issuing-billing-transaction

# Change
Adding resources in issuing-billing-invoice and issuing-billing-transaction

# Rollback Plan
Apply previous production tag v0.15.0 

# Acceptance Criteria
- [ ] Perform get with the Id of the billing-invoice and page, query with the filters [after=date(2025, 1, 1), before=date(2025, 3, 1), limit = 1] in issuing-billing-invoice  
- [ ] Perform query and page with the filters [after=date(2025, 1, 1), before=date(2025, 3, 1), limit = 1] in issuing-billing-transaction